### PR TITLE
chore(release): bump version to 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 6.1.0
+
+### Added
+- `AdvancedEmailExtractor` class that normalizes common email obfuscations (`[at]`, `(dot)`, etc.), decodes Cloudflare `data-cfemail` protected addresses, and filters junk/system emails for cleaner results
+- Documentation for `extract_emails.data_extractors.advanced_email_extractor` in docs
+
+### Changed
+- URL normalization now treats www/apex variants (e.g., `example.com` and `www.example.com`) as same-site, preventing extraction failures when browsers follow redirects
+
+### Fixed
+- Link filtering now correctly handles redirects from `example.com` to `www.example.com` (and vice versa)
+- Resolves issue #40 (email extraction improvements)
+
 ## 6.0.2
 
 ### Added

--- a/extract_emails/__init__.py
+++ b/extract_emails/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "6.0.2"
+__version__ = "6.1.0"
 from .workers import DefaultWorker
 
 __all__ = ("DefaultWorker",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "extract-emails"
-version = "6.0.2"
+version = "6.1.0"
 requires-python = ">=3.10,<3.15"
 description = "Extract email addresses and linkedin profiles from given URL."
 authors = [


### PR DESCRIPTION
Update CHANGELOG.md with changes from PRs #47 and #46:

- Added AdvancedEmailExtractor with obfuscation normalization and Cloudflare email decoding

- Fixed URL normalization for www/apex redirects

- Resolves issue #40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release 6.1.0 with feature and stability updates.
> 
> - Adds `AdvancedEmailExtractor` (normalizes obfuscations, decodes Cloudflare `data-cfemail`, filters junk/system emails) and corresponding docs
> - Changes URL normalization to treat apex/`www` as same-site to avoid extraction failures
> - Fixes link filtering across redirects between `example.com` and `www.example.com`
> - Updates version in `pyproject.toml` and `extract_emails/__init__.py`; refreshes `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80f4cfbe5c60d3d7d8f31dad59a17a3442eb85a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->